### PR TITLE
Changes to environment.yaml to make conda install possible

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -91,4 +91,3 @@ dependencies:
     - werkzeug==2.2.2
     - yarl==1.8.2
     - zipp==3.11.0
-prefix: /home/jszym/mambaforge-pypy3/envs/rapppid

--- a/environment.yml
+++ b/environment.yml
@@ -2,11 +2,13 @@ name: rapppid
 channels:
   - defaults
   - conda-forge
+  - pytorch
 dependencies:
   - _libgcc_mutex=0.1
   - _openmp_mutex=5.1
   - ca-certificates=2022.10.11
   - certifi=2022.12.7
+  - cudatoolkit=11.1
   - ld_impl_linux-64=2.38
   - libffi=3.4.2
   - libgcc-ng=11.2.0
@@ -16,6 +18,7 @@ dependencies:
   - openssl=1.1.1s
   - pip=22.3.1
   - python=3.8.15
+  - pytorch=1.9.0=py3.8_cuda11.1_cudnn8.0.5_0
   - readline=8.2
   - sqlite=3.40.1
   - tk=8.6.12
@@ -66,7 +69,7 @@ dependencies:
     - python-dateutil==2.8.2
     - pytorch-lightning==1.3.8
     - pyyaml==5.4.1
-    - ranger21==0.0.1
+    - git+https://github.com/lessw2020/Ranger21.git
     - requests==2.28.2
     - requests-oauthlib==1.3.1
     - rsa==4.9
@@ -81,7 +84,6 @@ dependencies:
     - tensorboard-plugin-wit==1.8.1
     - termcolor==2.2.0
     - threadpoolctl==3.1.0
-    - torch==1.9.0+cu111
     - torchmetrics==0.4.1
     - tqdm==4.64.1
     - typing-extensions==4.4.0


### PR DESCRIPTION
Hey Joseph,

Jake here from U of Michigan (we met at ISMB last summer). I recently went to install RAPPPID and was not able to create a conda env from the supplied environment.yaml.

There were two problems:

1. Ranger21 does not seem to exist on PYPI anymore, not sure why. I fixed this by adding their git repo as the pip source, as outlined on their [README](https://github.com/lessw2020/Ranger21/blob/main/README.md).
2. pip could not find a cuda 11.1 build of torch 1.9.0 for python 3.8. I was able to get around this by instead installing torch via the pytorch conda channel using the specific build `py3.8_cuda11.1_cudnn8.0.5_0` along with cudatoolkit. 

With this modified environment.yaml, installation worked perfectly with `$ mamba install -f environment.yaml -p ./env`.

I'm not sure if this was system specific, but I hope you might find these changes helpful regardless.

Thanks! 
